### PR TITLE
Update OAuth 2.0 provider example in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ That's it! 🎉 Others will be able to discover this provider much more easily n
 
 You can look at the existing built-in providers for inspiration.
 - If you are adding a new OIDC provider, take a look at [auth0.ts](https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/providers/auth0.ts).
-- If you are adding a new OAuth 2.0 provider, take a look at [google.ts](https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/providers/google.ts).
+- If you are adding a new OAuth 2.0 provider, take a look at [facebook.ts](https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/providers/facebook.ts).
 
 #### Adding a new Database Adapter
 


### PR DESCRIPTION
This pull request updates the OAuth 2.0 provider example in the CONTRIBUTING.md file.

The existing example for adding a new OAuth 2.0 provider has been replaced with a reference to the facebook.ts file in the repository.
google.ts is not an appropriate  OAuth 2.0 example because it uses OIDC. Since this pull request is intended to raise the issue, the example provider can be changed from facebook.ts instead.

This change provides more accurate and up-to-date information for contributors.